### PR TITLE
Fix title yosemite

### DIFF
--- a/metacity-1/metacity-theme-3.xml
+++ b/metacity-1/metacity-theme-3.xml
@@ -48,6 +48,7 @@
          x="(0 `max` ((width - title_width) / 2))"
          y="(0 `max` ((height - title_height) / 2)) + 1"
          color="#4c4c4c" />
+
   <title version=">= 3.1"
          x="(0 `max` ((frame_x_center - title_width / 2) `min` (width - title_wi
 dth)))"

--- a/metacity-1/metacity-theme-3.xml
+++ b/metacity-1/metacity-theme-3.xml
@@ -44,11 +44,28 @@
 </frame_geometry>
 
 <draw_ops name="title-text-focused">
- <title color="#4c4c4c" x="(0 `max` (width-title_width-mini_icon_width-IconTitleSpacing)) / 2 + mini_icon_width + IconTitleSpacing -72" y="(height - title_height) / 2 - 3"/>
+  <title version="< 3.1"
+         x="(0 `max` ((width - title_width) / 2))"
+         y="(0 `max` ((height - title_height) / 2)) + 1"
+         color="#4c4c4c" />
+  <title version=">= 3.1"
+         x="(0 `max` ((frame_x_center - title_width / 2) `min` (width - title_wi
+dth)))"
+         y="(0 `max` ((height - title_height) / 2)) + 1"
+         ellipsize_width="width"
+         color="#4c4c4c" />
 </draw_ops>
 
 <draw_ops name="title-text-unfocused">
-  <title color="#9f9f9f" x="(0 `max` (width-title_width-mini_icon_width-IconTitleSpacing)) / 2 + mini_icon_width + IconTitleSpacing -72" y="(height - title_height) / 2 - 3"/>
+  <title version="< 3.1"
+         x="(0 `max` ((width - title_width) / 2))"
+         y="(0 `max` ((height - title_height) / 2)) + 1"
+         color="#9f9f9f" />
+  <title version=">= 3.1"
+         x="(0 `max` ((frame_x_center - title_width / 2) `min` (width - title_width)))"
+         y="(0 `max` ((height - title_height) / 2)) + 1"
+         ellipsize_width="width"
+         color="#9f9f9f" />
 </draw_ops>
 
 <draw_ops name="blank">


### PR DESCRIPTION
Correct title in titlebar for Gnome 3.2 (from cu-off left to center)